### PR TITLE
Updated build script to include the app version

### DIFF
--- a/get_your_utils/powershell/dev_deploy/BuildDeployDocker.ps1
+++ b/get_your_utils/powershell/dev_deploy/BuildDeployDocker.ps1
@@ -24,12 +24,19 @@ if ( $proc.ExitCode -eq 0 ) {
 
     $BuildStr = "$($env:DOCKER_ACCOUNT)/$($env:DOCKER_REPO):$($env:BUILD_TAG)"
 
+    ## Add the Git version file (to be removed after build)
+    # Run the Git command in the DEPLOY_DIR directory (-C flag)
+    git -C $env:DEPLOY_DIR describe --tags | Out-File -Encoding utf8 $(Join-Path $env:DEPLOY_DIR ".gitversion")
+
     ## Run the Docker build and push
     Write-Host "`nBuilding into $BuildStr..."
     docker build -t $BuildStr $env:DEPLOY_DIR
 
     Write-Host "`nPushing to Docker hub..."
     docker push $BuildStr
+
+    ## Remove the Git version file (it's to be used within a Docker build only)
+    Remove-Item $(Join-Path $env:DEPLOY_DIR ".gitversion")
 
     Read-Host -Prompt "Script complete. Press any key to exit"
 


### PR DESCRIPTION
As expected from the new database logging in `Get-Your`, this creates a file with the app version from the Git repo tags.