### PR TITLE
v4.0.0 RC

### DIFF
--- a/get_your_utils/python/run_extracts.py
+++ b/get_your_utils/python/run_extracts.py
@@ -998,13 +998,14 @@ class Extract:
                     [tuple([x] + list(y)) for x,y in zip(notesList, dbOut)],
                     )
 
-                # Add column for 'Enrolled in Program' and set based on notes
-                # field
-                # NOTE that this assumes a user is already enrolled only if
-                # notes starts with 'update' (case-insensitive)
-                df = df.assign(
-                    **{'Enrolled in Program': [True if isinstance(x, str) and x.lower().startswith('update') else False for x in df['Notes']]},
-                    )
+                # Add column for 'Enrolled in Program' (if `not mark_enrolled`)
+                # and set based on notes field
+                if not mark_enrolled:
+                    # NOTE that this assumes a user is already enrolled only if
+                    # notes starts with 'update' (case-insensitive)
+                    df = df.assign(
+                        **{'Enrolled in Program': [True if isinstance(x, str) and x.lower().startswith('update') else False for x in df['Notes']]},
+                        )
                 
                 ## Data validation
                 
@@ -1068,8 +1069,12 @@ class Extract:
                         # Some issue with reading the file; go to the next
                         continue
                     
-                    # Filter for only enrolled==true
-                    checkDf = checkDf[checkDf['Enrolled in Program'].apply(lambda x: x==True)]
+                    # Filter for only enrolled==true if this column exists;
+                    # else, assume all users in the extract are enrolled
+                    try:
+                        checkDf = checkDf[checkDf['Enrolled in Program'].apply(lambda x: x==True)]
+                    except KeyError:
+                        pass
                     
                     if len(checkDf) > 0:
                         checkData = list(


### PR DESCRIPTION
To accompany the [Get-Your v4.0.1 release](https://github.com/Get-Your/Get-Your/releases/tag/v4.0.1):

- Removed 'renewals' section. The logic used for the GTR-only renewals in v3 is no longer valid, so the Notes message '<year> RENEWAL' is no longer an option.
- Add the option (default `True`) to mark an applicant 'enrolled' at the time their extract is pulled
    - To streamline the process that involves multiple program coordinators, Get FoCo is now marking applicants 'enrolled' in the program at the time the program's extract is pulled rather than waiting for coordinator feedback
    - Also removed the 'Enrolled in Program' column for extracts where applicants are automatically marked 'enrolled'